### PR TITLE
埋込みdataによる變換coreを追加

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,144 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
 name = "segzify"
 version = "0.1.0"
+dependencies = [
+ "regex",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ name = "segzify"
 path = "src/main.rs"
 
 [dependencies]
+regex = "1.13.1"
+serde = { version = "1.0.229", features = ["derive"] }
+serde_json = "1.0.151"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 use std::collections::BTreeMap;
 
 #[derive(Debug, Deserialize)]
-struct KyujiMap {
+struct SegziMap {
     char_map: BTreeMap<String, String>,
     ambiguous_characters: BTreeMap<String, Vec<Candidate>>,
 }
@@ -64,10 +64,10 @@ fn char_map(rows: Vec<(String, String)>) -> BTreeMap<char, String> {
 
 impl Converter {
     pub fn embedded() -> Result<Self, String> {
-        let kyuji: KyujiMap = serde_json::from_str(include_str!("../dic/kyuji_map.json"))
+        let segzi: SegziMap = serde_json::from_str(include_str!("../dic/kyuji_map.json"))
             .map_err(|error| error.to_string())?;
         let mut ambiguous = BTreeMap::new();
-        for (source, candidates) in kyuji.ambiguous_characters {
+        for (source, candidates) in segzi.ambiguous_characters {
             if let Some(character) = source.chars().next() {
                 ambiguous.insert(
                     character,
@@ -95,7 +95,7 @@ impl Converter {
         Ok(Self {
             zh_compounds: replacement_rows(include_str!("../dic/zh_compound_map.tsv")),
             zh_chars: char_map(rows(include_str!("../dic/zh_char_map.tsv"))),
-            chars: char_map(kyuji.char_map.into_iter().collect()),
+            chars: char_map(segzi.char_map.into_iter().collect()),
             kana: rows(include_str!("../dic/kana_replacements.tsv")),
             patterns: rows(include_str!("../dic/kana_patterns.tsv"))
                 .into_iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,174 @@
+use regex::Regex;
+use serde::Deserialize;
+use std::collections::BTreeMap;
+
+#[derive(Debug, Deserialize)]
+struct KyujiMap {
+    char_map: BTreeMap<String, String>,
+    ambiguous_characters: BTreeMap<String, Vec<Candidate>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Candidate {
+    target: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AmbiguousCharacter {
+    pub character: String,
+    pub count: usize,
+    pub candidates: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Report {
+    pub unresolved_ambiguous_characters: Vec<AmbiguousCharacter>,
+}
+
+pub struct Converter {
+    zh_compounds: Vec<(String, String)>,
+    zh_chars: BTreeMap<char, String>,
+    chars: BTreeMap<char, String>,
+    kana: Vec<(String, String)>,
+    patterns: Vec<(Regex, String)>,
+    ambiguous: BTreeMap<char, Vec<String>>,
+}
+
+fn rows(input: &str) -> Vec<(String, String)> {
+    input
+        .lines()
+        .filter_map(|line| {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') {
+                return None;
+            }
+            let mut fields = line.split('\t');
+            Some((fields.next()?.to_owned(), fields.next()?.to_owned()))
+        })
+        .collect()
+}
+
+fn replacement_rows(input: &str) -> Vec<(String, String)> {
+    let mut result = rows(input);
+    result.sort_by_key(|(from, _)| std::cmp::Reverse(from.chars().count()));
+    result
+}
+
+fn char_map(rows: Vec<(String, String)>) -> BTreeMap<char, String> {
+    rows.into_iter()
+        .filter_map(|(from, to)| {
+            (from.chars().count() == 1).then(|| (from.chars().next().unwrap(), to))
+        })
+        .collect()
+}
+
+impl Converter {
+    pub fn embedded() -> Result<Self, String> {
+        let kyuji: KyujiMap = serde_json::from_str(include_str!("../dic/kyuji_map.json"))
+            .map_err(|error| error.to_string())?;
+        let mut ambiguous = BTreeMap::new();
+        for (source, candidates) in kyuji.ambiguous_characters {
+            if let Some(character) = source.chars().next() {
+                ambiguous.insert(
+                    character,
+                    candidates
+                        .into_iter()
+                        .map(|candidate| candidate.target.unwrap_or(source.clone()))
+                        .collect(),
+                );
+            }
+        }
+        let zh_ambiguous: BTreeMap<String, Vec<Candidate>> =
+            serde_json::from_str(include_str!("../dic/zh_ambiguous_characters.json"))
+                .map_err(|error| error.to_string())?;
+        for (source, candidates) in zh_ambiguous {
+            if let Some(character) = source.chars().next() {
+                ambiguous.insert(
+                    character,
+                    candidates
+                        .into_iter()
+                        .map(|candidate| candidate.target.unwrap_or(source.clone()))
+                        .collect(),
+                );
+            }
+        }
+        Ok(Self {
+            zh_compounds: replacement_rows(include_str!("../dic/zh_compound_map.tsv")),
+            zh_chars: char_map(rows(include_str!("../dic/zh_char_map.tsv"))),
+            chars: char_map(kyuji.char_map.into_iter().collect()),
+            kana: rows(include_str!("../dic/kana_replacements.tsv")),
+            patterns: rows(include_str!("../dic/kana_patterns.tsv"))
+                .into_iter()
+                .map(|(pattern, replacement)| {
+                    Regex::new(&pattern)
+                        .map(|regex| (regex, replacement))
+                        .map_err(|e| e.to_string())
+                })
+                .collect::<Result<_, _>>()?,
+            ambiguous,
+        })
+    }
+
+    pub fn convert(&self, source: &str) -> (String, Report) {
+        let mut text = source.to_owned();
+        for (from, to) in &self.zh_compounds {
+            text = text.replace(from, to);
+        }
+        text = translate(&text, &self.zh_chars);
+        text = translate(&text, &self.chars);
+        for (from, to) in &self.kana {
+            text = text.replace(from, to);
+        }
+        for (pattern, replacement) in &self.patterns {
+            text = pattern.replace_all(&text, replacement).into_owned();
+        }
+        let mut unresolved_ambiguous_characters: Vec<_> = self
+            .ambiguous
+            .iter()
+            .filter_map(|(character, candidates)| {
+                let count = source
+                    .chars()
+                    .filter(|c| c == character)
+                    .count()
+                    .min(text.chars().filter(|c| c == character).count());
+                (count > 0).then(|| AmbiguousCharacter {
+                    character: character.to_string(),
+                    count,
+                    candidates: candidates.clone(),
+                })
+            })
+            .collect();
+        unresolved_ambiguous_characters
+            .sort_by(|a, b| b.count.cmp(&a.count).then(a.character.cmp(&b.character)));
+        (
+            text,
+            Report {
+                unresolved_ambiguous_characters,
+            },
+        )
+    }
+}
+
+fn translate(text: &str, map: &BTreeMap<char, String>) -> String {
+    text.chars()
+        .map(|character| {
+            map.get(&character)
+                .cloned()
+                .unwrap_or_else(|| character.to_string())
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Converter;
+
+    #[test]
+    fn converts_embedded_non_boundary_stages() {
+        let converter = Converter::embedded().unwrap();
+        let (text, report) =
+            converter.convert("きょうという日は待っているようです。删除制造干后。");
+        assert_eq!(text, "けふといふ日は待ってゐるやうです。削除製造干后。");
+        assert_eq!(report.unresolved_ambiguous_characters.len(), 2);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,9 +173,11 @@ mod tests {
         let converter = Converter::embedded().unwrap();
         let (text, report) = converter.convert("证");
         assert_eq!(text, "証");
-        assert!(report
-            .unresolved_ambiguous_characters
-            .iter()
-            .any(|item| item.character == "証" && item.count == 1));
+        assert!(
+            report
+                .unresolved_ambiguous_characters
+                .iter()
+                .any(|item| item.character == "証" && item.count == 1)
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,11 +126,7 @@ impl Converter {
             .ambiguous
             .iter()
             .filter_map(|(character, candidates)| {
-                let count = source
-                    .chars()
-                    .filter(|c| c == character)
-                    .count()
-                    .min(text.chars().filter(|c| c == character).count());
+                let count = text.chars().filter(|c| c == character).count();
                 (count > 0).then(|| AmbiguousCharacter {
                     character: character.to_string(),
                     count,
@@ -170,5 +166,16 @@ mod tests {
             converter.convert("きょうという日は待っているようです。删除制造干后。");
         assert_eq!(text, "けふといふ日は待ってゐるやうです。削除製造干后。");
         assert_eq!(report.unresolved_ambiguous_characters.len(), 2);
+    }
+
+    #[test]
+    fn reports_ambiguity_created_by_chinese_character_conversion() {
+        let converter = Converter::embedded().unwrap();
+        let (text, report) = converter.convert("证");
+        assert_eq!(text, "証");
+        assert!(report
+            .unresolved_ambiguous_characters
+            .iter()
+            .any(|item| item.character == "証" && item.count == 1));
     }
 }


### PR DESCRIPTION
dicをbinaryへ埋込み、形態素解析を要しない變換stageと曖昧字reportを追加する。

日本語熟語の境界保護は後續PRで追加する。